### PR TITLE
Fix AI chat provider error handling for issue #35

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,6 +301,7 @@ Notes:
 | Variable         | Purpose                          | Default                              |
 | ---------------- | -------------------------------- | ------------------------------------ |
 | `GEMINI_API_KEY` | Google AI key (for chat feature) | (disabled)                           |
+| `GEMINI_MODEL`   | Gemini model override            | `gemini-2.5-flash`                   |
 | `AI_ENABLED`     | Enable AI advisor                | `false`                              |
 | `VITE_API_BASE`  | Frontend API endpoint            | `http://localhost:3000`              |
 | `STORAGE_METHOD` | Storage method for data          | `postgres` (recommended) or `memory` |
@@ -312,8 +313,11 @@ Notes:
 1. Get free key from [Google AI Studio](https://aistudio.google.com/)
 2. Set `GEMINI_API_KEY` in backend `.env`
 3. Set `AI_ENABLED=true`
-4. Restart backend
-5. Chat bubble appears in top-right header
+4. Optional: if your key works with `gemini-flash-latest` but chat still fails, set `GEMINI_MODEL=gemini-flash-latest`
+5. Reload backend configuration
+  Docker Compose: `docker compose up -d --force-recreate backend`
+  Manual backend: restart `pnpm dev`
+6. Chat bubble appears in top-right header
 
 **Full guide:** [docs/AI_ADVISOR.md](docs/AI_ADVISOR.md)
 

--- a/README.md
+++ b/README.md
@@ -315,8 +315,8 @@ Notes:
 3. Set `AI_ENABLED=true`
 4. Optional: if your key works with `gemini-flash-latest` but chat still fails, set `GEMINI_MODEL=gemini-flash-latest`
 5. Reload backend configuration
-  Docker Compose: `docker compose up -d --force-recreate backend`
-  Manual backend: restart `pnpm dev`
+   Docker Compose: `docker compose up -d --force-recreate backend`
+   Manual backend: restart `pnpm dev`
 6. Chat bubble appears in top-right header
 
 **Full guide:** [docs/AI_ADVISOR.md](docs/AI_ADVISOR.md)

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -20,6 +20,7 @@ ADMIN_SECRET=your-admin-secret-here
 # AI Advisor (optional - Google AI Studio API key)
 # Get free key at: https://aistudio.google.com/
 GEMINI_API_KEY=
+GEMINI_MODEL=gemini-2.5-flash
 AI_ENABLED=false
 
 # Note: If AI_ENABLED=false or GEMINI_API_KEY is empty,

--- a/backend/README.md
+++ b/backend/README.md
@@ -22,6 +22,7 @@ The AI chat feature is **optional and disabled by default**:
 
 - Requires Google AI Studio API key (free tier available)
 - Routes only registered if `AI_ENABLED=true` and `GEMINI_API_KEY` is set
+- Optional `GEMINI_MODEL` override if your API key/account needs a different Gemini model alias
 - Core budgeting features work fully without the AI key
 - Frontend shows a friendly "AI disabled" message when not configured
 

--- a/backend/src/application/errors/error-mapper.ts
+++ b/backend/src/application/errors/error-mapper.ts
@@ -1,6 +1,7 @@
 import { ZodError } from 'zod';
 import { DomainError } from '../../domain/exceptions/domain-error.js';
 import { ValidationError } from '../../domain/exceptions/validation-error.js';
+import { UserFacingError } from '../../shared/errors/user-facing-error.js';
 import type { IApplicationError } from './application-error.interface.js';
 
 /**
@@ -65,6 +66,16 @@ export class ErrorMapper {
         isDomainError: true,
         code: 'DOMAIN_ERROR',
       };
+    }
+
+    if (error instanceof UserFacingError) {
+      return {
+        statusCode: error.statusCode,
+        message: error.message,
+        isDomainError: false,
+        code: error.code,
+        ...(isDevelopment && error.details ? { details: error.details } : {}),
+      } satisfies IApplicationError;
     }
 
     // Generic Error

--- a/backend/src/infrastructure/ai/gemini-ai-provider.ts
+++ b/backend/src/infrastructure/ai/gemini-ai-provider.ts
@@ -1,6 +1,6 @@
 import { GoogleGenAI } from '@google/genai';
-import { DomainError } from '../../domain/exceptions/domain-error.js';
 import type { AiResponse, IAiProvider, TokenUsage } from '../../domain/services/ai-provider.interface.js';
+import { UserFacingError } from '../../shared/errors/user-facing-error.js';
 
 type GeminiUsageMetadata = {
   promptTokenCount?: number;
@@ -17,11 +17,16 @@ type GeminiGenerateContentResponse = {
  * GeminiAiProviderError: Domain error for Gemini API failures.
  * Thrown when the Google Gen AI API call fails.
  * 
- * @extends DomainError
+ * @extends UserFacingError
  */
-export class GeminiAiProviderError extends DomainError {
-  constructor(message: string) {
-    super(`Gemini AI Provider Error: ${message}`);
+export class GeminiAiProviderError extends UserFacingError {
+  constructor(message: string, details?: Record<string, unknown>) {
+    super(
+      502,
+      'AI_PROVIDER_ERROR',
+      message,
+      details,
+    );
     Object.setPrototypeOf(this, GeminiAiProviderError.prototype);
   }
 }
@@ -48,7 +53,9 @@ export class GeminiAiProviderError extends DomainError {
  */
 export class GeminiAiProvider implements IAiProvider {
   private readonly client: GoogleGenAI;
-  private readonly modelName = 'gemini-2.5-flash';
+  static readonly DEFAULT_MODEL_NAME = 'gemini-2.5-flash';
+
+  private readonly modelName: string;
   private readonly systemInstruction: string;
 
   /**
@@ -58,7 +65,7 @@ export class GeminiAiProvider implements IAiProvider {
    * @param systemInstruction - System-level instruction for model behavior (e.g., Barefoot methodology)
    * @throws GeminiAiProviderError if apiKey is missing or invalid
    */
-  constructor(apiKey: string, systemInstruction: string) {
+  constructor(apiKey: string, systemInstruction: string, modelName = GeminiAiProvider.DEFAULT_MODEL_NAME) {
     if (!apiKey || typeof apiKey !== 'string') {
       throw new GeminiAiProviderError('API key is required and must be a string');
     }
@@ -67,8 +74,13 @@ export class GeminiAiProvider implements IAiProvider {
       throw new GeminiAiProviderError('System instruction is required and must be a string');
     }
 
+    if (!modelName || typeof modelName !== 'string' || modelName.trim().length === 0) {
+      throw new GeminiAiProviderError('Model name is required and must be a non-empty string');
+    }
+
     this.client = new GoogleGenAI({ apiKey });
     this.systemInstruction = systemInstruction;
+    this.modelName = modelName.trim();
   }
 
   /**
@@ -127,9 +139,15 @@ export class GeminiAiProvider implements IAiProvider {
         throw error;
       }
 
-      // Otherwise, wrap in GeminiAiProviderError
       const errorMessage = error instanceof Error ? error.message : 'Unknown error';
-      throw new GeminiAiProviderError(`Failed to generate response: ${errorMessage}`);
+      console.error(`[AI] Gemini request failed for model "${this.modelName}"`, error);
+      throw new GeminiAiProviderError(
+        'AI advisor request failed. Please try again in a moment. If this keeps happening, check the backend logs or verify the Gemini model configuration.',
+        {
+          model: this.modelName,
+          originalError: errorMessage,
+        },
+      );
     }
   }
 }

--- a/backend/src/infrastructure/ai/gemini-ai-provider.ts
+++ b/backend/src/infrastructure/ai/gemini-ai-provider.ts
@@ -14,7 +14,7 @@ type GeminiGenerateContentResponse = {
 };
 
 /**
- * GeminiAiProviderError: Domain error for Gemini API failures.
+ * GeminiAiProviderError: User-facing error for Gemini API failures.
  * Thrown when the Google Gen AI API call fails.
  * 
  * @extends UserFacingError
@@ -33,7 +33,8 @@ export class GeminiAiProviderError extends UserFacingError {
 
 /**
  * GeminiAiProvider: Implements IAiProvider using Google Gen AI SDK.
- * Uses the gemini-2.5-flash model for speed and efficiency.
+ * Uses `GeminiAiProvider.DEFAULT_MODEL_NAME` by default, with an optional
+ * constructor override for deployments that need a different Gemini alias.
  * 
  * IMPORTANT: Accepts systemInstruction in constructor to enforce strict
  * behavioral guidelines (e.g., Barefoot Investor methodology). This is

--- a/backend/src/presentation/http/app.ts
+++ b/backend/src/presentation/http/app.ts
@@ -193,18 +193,19 @@ export async function createApp(): Promise<Application> {
   let sendChatMessageUseCase: SendChatMessageUseCase | null = null;
   const aiEnabled = process.env.AI_ENABLED === 'true';
   const apiKey = process.env.GEMINI_API_KEY;
+  const aiModel = process.env.GEMINI_MODEL?.trim() || GeminiAiProvider.DEFAULT_MODEL_NAME;
 
   if (aiEnabled && apiKey) {
     const advisorService = new BarefootAdvisorService();
     const systemInstruction = advisorService.getSystemPrompt(); // Get strict Barefoot methodology
-    const aiProvider = new GeminiAiProvider(apiKey, systemInstruction);
+    const aiProvider = new GeminiAiProvider(apiKey, systemInstruction, aiModel);
     sendChatMessageUseCase = new SendChatMessageUseCase(
       profileRepo,
       debtRepo,
       fortnightRepo,
       aiProvider,
     );
-    console.log('AI Chat advisor enabled');
+    console.log(`AI Chat advisor enabled (model: ${aiModel})`);
   } else if (aiEnabled && !apiKey) {
     console.warn(
       'AI_ENABLED=true but GEMINI_API_KEY not set. AI Chat advisor disabled. To enable, set both AI_ENABLED=true and GEMINI_API_KEY.',

--- a/backend/src/shared/errors/user-facing-error.ts
+++ b/backend/src/shared/errors/user-facing-error.ts
@@ -1,0 +1,12 @@
+export class UserFacingError extends Error {
+  constructor(
+    public readonly statusCode: number,
+    public readonly code: string,
+    message: string,
+    public readonly details?: Record<string, unknown>,
+  ) {
+    super(message);
+    this.name = this.constructor.name;
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}

--- a/backend/tests/unit/infrastructure/ai/gemini-ai-provider.test.ts
+++ b/backend/tests/unit/infrastructure/ai/gemini-ai-provider.test.ts
@@ -1,0 +1,91 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  GeminiAiProvider,
+  GeminiAiProviderError,
+} from '../../../../src/infrastructure/ai/gemini-ai-provider.js';
+
+describe('GeminiAiProvider', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('uses the configured model name when generating content', async () => {
+    const provider = new GeminiAiProvider('test-key', 'System instruction', 'gemini-flash-latest');
+    const generateContent = vi.fn().mockResolvedValue({
+      text: 'Helpful answer',
+      usageMetadata: {
+        promptTokenCount: 10,
+        candidatesTokenCount: 20,
+        totalTokenCount: 30,
+      },
+    });
+
+    (provider as unknown as { client: { models: { generateContent: typeof generateContent } } }).client = {
+      models: { generateContent },
+    };
+
+    const response = await provider.generateResponse('How do I budget?', 'User context');
+
+    expect(generateContent).toHaveBeenCalledWith({
+      model: 'gemini-flash-latest',
+      contents: [
+        {
+          role: 'user',
+          parts: [{ text: 'User context\n\nUser: How do I budget?' }],
+        },
+      ],
+      config: {
+        systemInstruction: 'System instruction',
+      },
+    });
+    expect(response).toEqual({
+      text: 'Helpful answer',
+      usage: {
+        promptTokens: 10,
+        completionTokens: 20,
+        totalTokens: 30,
+      },
+    });
+  });
+
+  it('throws a provider error when Gemini returns no text', async () => {
+    const provider = new GeminiAiProvider('test-key', 'System instruction');
+    const generateContent = vi.fn().mockResolvedValue({ text: '   ' });
+
+    (provider as unknown as { client: { models: { generateContent: typeof generateContent } } }).client = {
+      models: { generateContent },
+    };
+
+    await expect(provider.generateResponse('Hello', 'User context')).rejects.toThrow(
+      GeminiAiProviderError,
+    );
+    await expect(provider.generateResponse('Hello', 'User context')).rejects.toThrow(
+      'Empty response from API',
+    );
+  });
+
+  it('logs and wraps provider failures with the active model name', async () => {
+    const provider = new GeminiAiProvider('test-key', 'System instruction', 'gemini-flash-latest');
+    const generateContent = vi.fn().mockRejectedValue(new Error('Model not found'));
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    (provider as unknown as { client: { models: { generateContent: typeof generateContent } } }).client = {
+      models: { generateContent },
+    };
+
+    await expect(provider.generateResponse('Hello', 'User context')).rejects.toMatchObject({
+      message:
+        'AI advisor request failed. Please try again in a moment. If this keeps happening, check the backend logs or verify the Gemini model configuration.',
+      code: 'AI_PROVIDER_ERROR',
+      statusCode: 502,
+      details: {
+        model: 'gemini-flash-latest',
+        originalError: 'Model not found',
+      },
+    });
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      '[AI] Gemini request failed for model "gemini-flash-latest"',
+      expect.any(Error),
+    );
+  });
+});

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,7 @@ services:
       # Use provided PG_CONNECTION_STRING, or default to local postgres service
       PG_CONNECTION_STRING: ${PG_CONNECTION_STRING:-postgresql://bucketwise:your-secure-password@postgres:5432/bucketwise}
       GEMINI_API_KEY: ${GEMINI_API_KEY:-}
+      GEMINI_MODEL: ${GEMINI_MODEL:-gemini-2.5-flash}
       JWT_SECRET: ${JWT_SECRET}
       ADMIN_SECRET: ${ADMIN_SECRET}
       AI_ENABLED: ${AI_ENABLED:-false}
@@ -108,6 +109,11 @@ x-casaos:
       label: Google AI API key (optional)
       description: Get free key from https://aistudio.google.com/ to enable AI advisor
     - container: backend
+      name: GEMINI_MODEL
+      label: Gemini model override
+      default: gemini-2.5-flash
+      description: Optional model name override if your API key requires a different Gemini alias
+    - container: backend
       name: AI_ENABLED
       label: Enable AI advisor
       default: "false"
@@ -126,6 +132,7 @@ x-casaos:
       - "Generate JWT_SECRET: openssl rand -base64 32"
       - "Generate ADMIN_SECRET: openssl rand -base64 32"
       - "Optional: Set GEMINI_API_KEY and AI_ENABLED=true for AI chat feature"
+      - "Optional: If AI chat fails with a valid key, try GEMINI_MODEL=gemini-flash-latest"
   ports:
     - container: frontend
       description: Web UI

--- a/docs/AI_ADVISOR.md
+++ b/docs/AI_ADVISOR.md
@@ -32,15 +32,24 @@ Edit your backend `.env` file:
 
 ```bash
 GEMINI_API_KEY=your-key-from-step-1
+GEMINI_MODEL=gemini-2.5-flash
 AI_ENABLED=true
 ```
 
-### Step 3: Restart Backend
+If your key works in Google AI Studio or with curl against `gemini-flash-latest` but Bucketwise chat still fails, try:
+
+```bash
+GEMINI_MODEL=gemini-flash-latest
+```
+
+### Step 3: Reload Backend
 
 **Docker Compose:**
 ```bash
-docker compose restart backend
+docker compose up -d --force-recreate backend
 ```
+
+`docker compose restart` does not reload changed environment variables from `.env`, so recreate the backend container after changing AI settings.
 
 **Manual:**
 ```bash
@@ -130,7 +139,7 @@ Follow the "Enabling AI Advisor" section above.
 **Check:**
 1. Is `GEMINI_API_KEY` set in backend `.env`?
 2. Is `AI_ENABLED=true` in backend `.env`?
-3. Did you restart the backend after changing `.env`?
+3. Did you recreate the Docker backend container after changing `.env`?
 4. Check browser console for errors: Press `F12` → Console tab
 
 **Solution:**
@@ -138,10 +147,14 @@ Follow the "Enabling AI Advisor" section above.
 # Verify backend configuration
 cd backend
 cat .env | grep GEMINI_API_KEY
+cat .env | grep GEMINI_MODEL
 cat .env | grep AI_ENABLED
 
-# Restart backend
-docker compose restart backend
+# Verify the running container received the variables
+docker compose exec backend env | grep GEMINI
+
+# Recreate backend so env changes are applied
+docker compose up -d --force-recreate backend
 # OR: Kill and re-run: pnpm dev
 ```
 
@@ -151,19 +164,28 @@ docker compose restart backend
 1. Invalid API key (typo, key revoked)
 2. API quota exceeded (hit rate limit or daily limit)
 3. Network issue (firewall, proxy blocking Google)
-4. Backend crash
+4. Configured Gemini model is not available for your API key/account
+5. Backend crash
 
 **Solutions:**
 1. Regenerate API key: [Google AI Studio](https://aistudio.google.com/)
 2. Wait a few minutes before trying again (rate limit)
-3. Check backend logs: `docker compose logs backend | grep -i gemini` or `grep -i gemini backend.log`
-4. Check your network connectivity
+3. Check backend logs: `docker compose logs backend --tail=100`
+4. If logs show a model-specific failure, try `GEMINI_MODEL=gemini-flash-latest`
+5. Recreate the backend container after changing `GEMINI_MODEL`
+6. Check your network connectivity
 
 ### "Invalid API key"
 
 - Double-check the key is copied correctly (no extra spaces)
 - Regenerate the key in [Google AI Studio](https://aistudio.google.com/)
 - Ensure `GEMINI_API_KEY` is exactly as shown in AI Studio (starts with `AIza...`)
+
+### Model mismatch or account compatibility issues
+
+- Bucketwise defaults to `GEMINI_MODEL=gemini-2.5-flash`
+- Some keys or accounts may succeed against `gemini-flash-latest` while failing on a specific model name
+- If your direct curl test works with `gemini-flash-latest` but the app fails, set `GEMINI_MODEL=gemini-flash-latest` and recreate the backend container
 
 ### High latency or slow responses
 

--- a/docs/SELF_HOSTING.md
+++ b/docs/SELF_HOSTING.md
@@ -279,11 +279,14 @@ The AI chat feature is optional and disabled by default.
 1. Get a free API key from [Google AI Studio](https://aistudio.google.com/)
 2. Set `GEMINI_API_KEY` in your `.env` file
 3. Set `AI_ENABLED=true`
-4. Restart the backend service:
+4. Optional: if your key works with `gemini-flash-latest` but Bucketwise chat still fails, set `GEMINI_MODEL=gemini-flash-latest`
+5. Reload the backend service:
    ```bash
-   docker compose restart backend
+  docker compose up -d --force-recreate backend
    # OR: kill and restart `pnpm dev` in backend terminal
    ```
+
+For Docker Compose deployments, `restart` does not reload changed environment variables from `.env`; recreate the backend container instead.
 
 The chat bubble will appear in the top-right header when enabled.
 
@@ -324,8 +327,15 @@ Error: connect ECONNREFUSED 127.0.0.1:5432
 
 - Ensure `GEMINI_API_KEY` is set
 - Ensure `AI_ENABLED=true`
+- Verify what the container received: `docker compose exec backend env | grep GEMINI`
 - Check backend logs: `docker compose logs backend`
-- Restart backend after changing environment variables
+- Recreate backend after changing environment variables: `docker compose up -d --force-recreate backend`
+
+### "AI advisor request failed" Message
+
+- Check backend logs for the actual provider error: `docker compose logs backend --tail=100`
+- If the log mentions the configured model, try `GEMINI_MODEL=gemini-flash-latest`
+- Recreate the backend container after changing `GEMINI_MODEL`
 
 ### JWT Errors (Login Fails)
 

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -11,12 +11,14 @@ COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 COPY frontend/package.json frontend/package.json
 COPY backend/package.json backend/package.json
 
-COPY tsconfig.json ./
-COPY frontend ./frontend
-
-# Install after the workspace source is present so pnpm links are created against
-# the final package layout used by the build.
+# Install all workspace dependencies from manifests first so source-only
+# frontend changes do not invalidate the dependency layer.
 RUN pnpm install --frozen-lockfile --prod=false --recursive
+
+COPY tsconfig.json ./
+COPY frontend/index.html frontend/vite.config.ts frontend/tsconfig.json frontend/tsconfig.app.json frontend/tsconfig.node.json ./frontend/
+COPY frontend/public ./frontend/public
+COPY frontend/src ./frontend/src
 
 # Set Vite environment variables for production build
 # These get baked into the JavaScript bundle at build time

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -11,11 +11,12 @@ COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 COPY frontend/package.json frontend/package.json
 COPY backend/package.json backend/package.json
 
-# Install all workspace dependencies (incl. dev) for build
-RUN pnpm install --frozen-lockfile
-
 COPY tsconfig.json ./
 COPY frontend ./frontend
+
+# Install after the workspace source is present so pnpm links are created against
+# the final package layout used by the build.
+RUN pnpm install --frozen-lockfile --prod=false --recursive
 
 # Set Vite environment variables for production build
 # These get baked into the JavaScript bundle at build time

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -19,6 +19,7 @@ import type {
   CsvImportPreviewResponse,
   CsvImportCommitRequest,
 } from './types.ts';
+import { ApiClientError, createApiClientError } from './errors.ts';
 
 const API_BASE = import.meta.env.VITE_API_BASE || '/api';
 const AUTH_BASE = import.meta.env.VITE_AUTH_BASE || '/auth';
@@ -105,27 +106,17 @@ async function request<T>(
   }
 
   if (!response.ok) {
-    // Try to read server error body for more context
-    try {
-      const errJson = (await response.json()) as ApiResponse<unknown>;
-      const serverMessage = errJson?.error?.message;
-      if (serverMessage) {
-        throw new Error(serverMessage);
-      }
-    } catch {
-      // ignore JSON parse errors
-    }
-    throw new Error(`Request failed: ${response.status} ${response.statusText}`);
+    throw await createApiClientError(response);
   }
 
   const json = (await response.json()) as ApiResponse<T>;
   if (!json.success) {
     const message = json.error?.message || 'Unknown error';
-    throw new Error(message);
+    throw new ApiClientError(message, 200, json.error?.code, json.error?.details);
   }
 
   if (json.data === undefined) {
-    throw new Error('No data returned');
+    throw new ApiClientError('No data returned', 200);
   }
 
   return json.data;
@@ -143,25 +134,16 @@ async function requestAuth<T>(path: string, method: HttpMethod, body?: unknown):
   });
 
   if (!response.ok) {
-    try {
-      const errJson = (await response.json()) as ApiResponse<unknown>;
-      const serverMessage = errJson?.error?.message;
-      if (serverMessage) {
-        throw new Error(serverMessage);
-      }
-    } catch {
-      // ignore JSON parse errors
-    }
-    throw new Error(`Request failed: ${response.status} ${response.statusText}`);
+    throw await createApiClientError(response);
   }
 
   const json = (await response.json()) as ApiResponse<T>;
   if (!json.success) {
     const message = json.error?.message || 'Unknown error';
-    throw new Error(message);
+    throw new ApiClientError(message, 200, json.error?.code, json.error?.details);
   }
   if (json.data === undefined) {
-    throw new Error('No data returned');
+    throw new ApiClientError('No data returned', 200);
   }
   return json.data;
 }
@@ -326,8 +308,7 @@ export const api = {
       body: formData,
     });
     if (!response.ok) {
-      const error = await response.json();
-      throw new Error(error.error?.message || 'Upload failed');
+      throw await createApiClientError(response, 'Upload failed');
     }
     const result = await response.json();
     return result.data;
@@ -363,8 +344,7 @@ export const api = {
     });
 
     if (!response.ok) {
-      const error = await response.json();
-      throw new Error(error.error?.message || 'Preview failed');
+      throw await createApiClientError(response, 'Preview failed');
     }
     const result = await response.json();
     return result.data;

--- a/frontend/src/api/errors.ts
+++ b/frontend/src/api/errors.ts
@@ -1,0 +1,62 @@
+import type { ApiResponse } from './types.ts';
+
+export class ApiClientError extends Error {
+  readonly statusCode: number;
+  readonly code?: string;
+  readonly details?: Record<string, unknown>;
+
+  constructor(
+    message: string,
+    statusCode: number,
+    code?: string,
+    details?: Record<string, unknown>,
+  ) {
+    super(message);
+    this.name = 'ApiClientError';
+    this.statusCode = statusCode;
+    this.code = code;
+    this.details = details;
+    Object.setPrototypeOf(this, ApiClientError.prototype);
+  }
+}
+
+export function isApiClientError(error: unknown): error is ApiClientError {
+  return error instanceof ApiClientError;
+}
+
+export function getErrorMessage(error: unknown, fallback: string): string {
+  if (error instanceof Error && error.message.trim()) {
+    return error.message;
+  }
+
+  if (typeof error === 'object' && error !== null && 'message' in error) {
+    const maybeMessage = (error as { message?: unknown }).message;
+    if (typeof maybeMessage === 'string' && maybeMessage.trim()) {
+      return maybeMessage;
+    }
+  }
+
+  return fallback;
+}
+
+export async function createApiClientError(
+  response: Response,
+  fallbackMessage?: string,
+): Promise<ApiClientError> {
+  let message = fallbackMessage || `Request failed: ${response.status} ${response.statusText}`;
+  let code: string | undefined;
+  let details: Record<string, unknown> | undefined;
+
+  try {
+    const errJson = (await response.json()) as ApiResponse<unknown>;
+    if (errJson?.error?.message) {
+      message = errJson.error.message;
+    }
+    code = errJson?.error?.code;
+    details = errJson?.error?.details;
+  } catch {
+    // Ignore non-JSON error bodies and fall back to status text.
+  }
+
+  return new ApiClientError(message, response.status, code, details);
+}

--- a/frontend/src/components/ChatWidget.tsx
+++ b/frontend/src/components/ChatWidget.tsx
@@ -17,6 +17,7 @@ import { IconSend, IconTrash } from '@tabler/icons-react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
+import { isApiClientError } from '../api/errors';
 import { useChat } from '../hooks/useChat';
 import { usePageContext } from '../hooks/usePageContext';
 import { showSuccess } from '../utils/notifications';
@@ -143,6 +144,9 @@ export function ChatWidget() {
     [pageContext?.page, getEmptyStateSuggestions]
   );
 
+  const isAiDisabledError =
+    isApiClientError(error) && error.statusCode === 404;
+
   return (
     <Drawer
       opened={isOpen}
@@ -179,7 +183,7 @@ export function ChatWidget() {
         <Divider />
 
         {/* AI Disabled notice */}
-        {error?.includes('404') || error?.includes('not found') ? (
+        {isAiDisabledError ? (
           <Alert color="yellow" title="AI Advisor Disabled" icon={null}>
             <Stack gap="xs">
               <Text size="sm">
@@ -199,7 +203,7 @@ export function ChatWidget() {
           </Alert>
         ) : error ? (
           <Alert color="red" title="Error" withCloseButton onClose={() => null}>
-            {error}
+            {error.message}
           </Alert>
         ) : null}
 

--- a/frontend/src/components/ChatWidget.tsx
+++ b/frontend/src/components/ChatWidget.tsx
@@ -47,7 +47,7 @@ import { TokenUsageIndicator } from './TokenUsageIndicator';
  */
 export function ChatWidget() {
   const { isOpen, closeChat } = useChatContext();
-  const { messages, isLoading, error, totalTokensUsed, sendMessage, clearMessages } = useChat();
+  const { messages, isLoading, error, totalTokensUsed, sendMessage, clearError, clearMessages } = useChat();
   const pageContext = usePageContext();
   const [inputValue, setInputValue] = useState('');
   const scrollRef = useRef<HTMLDivElement>(null);
@@ -193,8 +193,11 @@ export function ChatWidget() {
                 <ol style={{ margin: '8px 0', paddingLeft: '20px' }}>
                   <li>Set <code>AI_ENABLED=true</code> in backend .env</li>
                   <li>Set <code>GEMINI_API_KEY=your_key</code> in backend .env</li>
-                  <li>Restart the backend service</li>
+                  <li>Reload the backend configuration</li>
                 </ol>
+                Docker Compose: <code>docker compose up -d --force-recreate backend</code>
+                <br />
+                Manual backend: restart <code>pnpm dev</code>
               </Text>
               <Text size="xs" c="dimmed">
                 See <a href="https://github.com/PaulAtkins88/bucketwise-planner/blob/main/docs/AI_ADVISOR.md" target="_blank" rel="noopener noreferrer">AI_ADVISOR.md</a> for details.
@@ -202,7 +205,7 @@ export function ChatWidget() {
             </Stack>
           </Alert>
         ) : error ? (
-          <Alert color="red" title="Error" withCloseButton onClose={() => null}>
+          <Alert color="red" title="Error" withCloseButton onClose={clearError}>
             {error.message}
           </Alert>
         ) : null}

--- a/frontend/src/hooks/useChat.ts
+++ b/frontend/src/hooks/useChat.ts
@@ -11,6 +11,7 @@ interface UseChatResult {
   error: ApiClientError | Error | null;
   totalTokensUsed: number;
   sendMessage: (message: string, pageContext?: PageContext) => Promise<void>;
+  clearError: () => void;
   clearMessages: () => void;
 }
 
@@ -107,12 +108,17 @@ export function useChat(): UseChatResult {
     setTotalTokensUsed(0);
   }, []);
 
+  const clearError = useCallback(() => {
+    setError(null);
+  }, []);
+
   return {
     messages,
     isLoading,
     error,
     totalTokensUsed,
     sendMessage,
+    clearError,
     clearMessages,
   };
 }

--- a/frontend/src/hooks/useChat.ts
+++ b/frontend/src/hooks/useChat.ts
@@ -1,4 +1,6 @@
 import { useCallback, useState } from 'react';
+import type { ApiClientError } from '../api/errors';
+import { getErrorMessage } from '../api/errors';
 import { api } from '../api/client';
 import type { ChatMessage, PageContext } from '../api/types';
 import { generateUUID } from '../utils/uuid';
@@ -6,7 +8,7 @@ import { generateUUID } from '../utils/uuid';
 interface UseChatResult {
   messages: ChatMessage[];
   isLoading: boolean;
-  error: string | null;
+  error: ApiClientError | Error | null;
   totalTokensUsed: number;
   sendMessage: (message: string, pageContext?: PageContext) => Promise<void>;
   clearMessages: () => void;
@@ -35,7 +37,7 @@ interface UseChatResult {
 export function useChat(): UseChatResult {
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [isLoading, setIsLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  const [error, setError] = useState<ApiClientError | Error | null>(null);
   const [totalTokensUsed, setTotalTokensUsed] = useState(0);
 
   const sendMessage = useCallback(async (messageText: string, pageContext?: PageContext) => {
@@ -89,8 +91,8 @@ export function useChat(): UseChatResult {
         setTotalTokensUsed((prev) => prev + (response.tokenUsage?.totalTokens ?? 0));
       }
     } catch (err) {
-      const errorMessage = err instanceof Error ? err.message : 'Failed to send message';
-      setError(errorMessage);
+      const nextError = err instanceof Error ? err : new Error(getErrorMessage(err, 'Failed to send message'));
+      setError(nextError);
       
       // Remove the user message on error to avoid confusion
       setMessages((prev) => prev.filter((msg) => msg.id !== userMessage.id));

--- a/frontend/src/views/LoginView.tsx
+++ b/frontend/src/views/LoginView.tsx
@@ -1,17 +1,7 @@
 import { Anchor, Button, Card, PasswordInput, Stack, Text, TextInput, Title } from '@mantine/core';
 import { useState } from 'react';
+import { getErrorMessage } from '../api/errors.ts';
 import { useAuth } from '../contexts/useAuth.ts';
-
-function getErrorMessage(err: unknown): string {
-  if (err instanceof Error) return err.message;
-
-  if (typeof err === 'object' && err !== null && 'message' in err) {
-    const maybeMessage = (err as { message?: unknown }).message;
-    if (typeof maybeMessage === 'string' && maybeMessage.trim()) return maybeMessage;
-  }
-
-  return 'Login failed';
-}
 
 interface LoginViewProps {
   onSwitch: () => void;
@@ -31,7 +21,7 @@ export function LoginView({ onSwitch }: LoginViewProps) {
     try {
       await login(email, password);
     } catch (err: unknown) {
-      setError(getErrorMessage(err));
+      setError(getErrorMessage(err, 'Login failed'));
     } finally {
       setLoading(false);
     }

--- a/frontend/src/views/SignupView.tsx
+++ b/frontend/src/views/SignupView.tsx
@@ -1,17 +1,7 @@
 import { Anchor, Button, Card, PasswordInput, Stack, Text, TextInput, Title } from '@mantine/core';
 import { useState } from 'react';
+import { getErrorMessage } from '../api/errors.ts';
 import { useAuth } from '../contexts/useAuth.ts';
-
-function getErrorMessage(err: unknown): string {
-  if (err instanceof Error) return err.message;
-
-  if (typeof err === 'object' && err !== null && 'message' in err) {
-    const maybeMessage = (err as { message?: unknown }).message;
-    if (typeof maybeMessage === 'string' && maybeMessage.trim()) return maybeMessage;
-  }
-
-  return 'Signup failed';
-}
 
 interface SignupViewProps {
   onSwitch: () => void;
@@ -32,7 +22,7 @@ export function SignupView({ onSwitch }: SignupViewProps) {
     try {
       await signup(email, name, password);
     } catch (err: unknown) {
-      setError(getErrorMessage(err));
+      setError(getErrorMessage(err, 'Signup failed'));
     } finally {
       setLoading(false);
     }


### PR DESCRIPTION
## Summary
Fixes the AI chat failure path reported in #35 by improving backend provider diagnostics, making the Gemini model configurable, and surfacing user-safe structured errors in the frontend.

## What changed
- add `GEMINI_MODEL` support and log the active model during backend startup
- wrap Gemini provider failures as user-facing `502 AI_PROVIDER_ERROR` responses while keeping technical details in backend logs
- preserve structured backend error payloads in the frontend API client
- stop misclassifying provider/model failures as "AI Advisor Disabled" in the chat widget
- share frontend API error helpers across chat and auth views
- fix the frontend Docker build ordering so workspace/dev dependencies resolve during image builds
- update self-hosting and AI docs to use `docker compose up -d --force-recreate backend` for env changes

## Validation
- `cd backend && pnpm exec tsc --noEmit`
- `cd backend && pnpm test -- --run tests/unit/infrastructure/ai/gemini-ai-provider.test.ts`
- `cd frontend && pnpm build`

Closes #35.